### PR TITLE
Strip UTF-8 BOM from source files

### DIFF
--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo.WinForms/TestControl.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo.WinForms/TestControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/InteropDemo.csproj
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/InteropDemo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/MainView.axaml
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/MainView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/MainView.axaml.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/MainView.axaml.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace InteropDemo;

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Program.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Avalonia;
 
 namespace InteropDemo;

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/MainViewModel.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia;

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/TabViewModel.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/TabViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using RoyalApps.Community.Avalonia.Windows.NativeControls;

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/TestViewModel.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/TestViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace InteropDemo.ViewModels;
+namespace InteropDemo.ViewModels;
 
 public class TestViewModel : TabViewModel
 {

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/ViewModelBase.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/ViewModels/ViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace InteropDemo.ViewModels;
 

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Views/TestView.axaml
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Views/TestView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Views/TestView.axaml.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Views/TestView.axaml.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 
 namespace InteropDemo.Views;
 

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Views/ViewLocator.cs
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/Views/ViewLocator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using InteropDemo.ViewModels;

--- a/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/app.manifest
+++ b/src/RoyalApps.Community.Avalonia.InteropDemo/InteropDemo/app.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
     <assemblyIdentity version="1.0.0.0" name="ControlCatalog.app"/>
 

--- a/src/RoyalApps.Community.Avalonia.Windows/NativeControls/IDisposeWinFormsControl.cs
+++ b/src/RoyalApps.Community.Avalonia.Windows/NativeControls/IDisposeWinFormsControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.Avalonia.Windows.NativeControls;
 

--- a/src/RoyalApps.Community.Avalonia.Windows/NativeControls/WinFormsControlHost.cs
+++ b/src/RoyalApps.Community.Avalonia.Windows/NativeControls/WinFormsControlHost.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Avalonia.Controls;
 using Avalonia.Platform;
 using Control = System.Windows.Forms.Control;

--- a/src/RoyalApps.Community.Avalonia.Windows/NativeControls/WinFormsLifetimeManager.cs
+++ b/src/RoyalApps.Community.Avalonia.Windows/NativeControls/WinFormsLifetimeManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Windows.Forms;

--- a/src/RoyalApps.Community.Avalonia.slnx
+++ b/src/RoyalApps.Community.Avalonia.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Configurations>
     <Platform Name="ARM64" />
     <Platform Name="x64" />


### PR DESCRIPTION
The byte-order marks are not necessary on any platform -- C#, .NET and current IDEs handle UTF-8 files just fine without them.